### PR TITLE
Fix update logic onSelect

### DIFF
--- a/packages/ngx-virtual-select-field/src/lib/virtual-select-field/virtual-select-field.component.ts
+++ b/packages/ngx-virtual-select-field/src/lib/virtual-select-field/virtual-select-field.component.ts
@@ -896,8 +896,8 @@ export class NgxVirtualSelectFieldComponent<TValue>
 
     const outputValue = this.multiple ? this._value : this._value[0];
 
-    this.valueChange.emit(outputValue);
     this._onChange(outputValue);
+    this.valueChange.emit(outputValue);
   }
 
   private assertIsDefined<T>(


### PR DESCRIPTION
When the change event is triggered listening to valueChange and updating other forms with the selected values formControl results in a one state behind. Therefore the formControl should be updated first and then the valueChange should trigger